### PR TITLE
Add optional global helper functions.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
             "Acf\\Test\\": "tests/_util/"
         },
         "files": [
+            "src/helpers.php",
             "tests/_util/Mock/functions.php"
         ]
     },

--- a/readme.md
+++ b/readme.md
@@ -95,6 +95,26 @@ use Acf\Acf;
 $toggle = Acf::option('toggle')->get();
 ```
 
+Alternatively, you can use the `fluent_*` helper functions to return a builder instance. The following functions will return a new builder for fields, sub fields, and options respectively:
+
+```php
+fluent_field('name');
+fluent_sub_field('name');
+fluent_option('name');
+```
+
+The field can then be retrieved by calling the `get` method as usual:
+
+```php
+$heading = fluent_field('heading')->get();
+```
+
+---
+
+**Note:** In order to use the helper functions, you must add the `"vendor/samrap/acf-fluent/src/helpers.php"` path in your `composer.json` [autoload files](https://getcomposer.org/doc/04-schema.md#files) setting to import them into your project.
+
+---
+
 The real power of ACF Fluent comes when we make full use of the builder. It provides methods such as `expect`, `default`, and `escape` that can be chained together to build powerful ACF "queries". Next, we will cover what each of these methods do and how to make use of them.
 
 ### Builder Methods

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -30,7 +30,7 @@ if (! function_exists('fluent_sub_field')) {
 }
 
 if (! function_exists('fluent_option')) {
-     /**
+    /**
      * Return a new builder instance for an option field call.
      *
      * @param  string  $name

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,0 +1,43 @@
+<?php
+
+use Acf\Acf;
+
+if (! function_exists('fluent_field')) {
+    /**
+     * Return a new builder instance for a field call.
+     *
+     * @param  string  $name
+     * @param  int  $id
+     * @return \Acf\Fluent\Builder
+     */
+    function fluent_field($name, $id = null)
+    {
+        return Acf::field($name, $id);
+    }
+}
+
+if (! function_exists('fluent_sub_field')) {
+    /**
+     * Return a new builder instance for a subfield call.
+     *
+     * @param  string  $name
+     * @return \Acf\Fluent\Builder
+     */
+    function fluent_sub_field($name)
+    {
+        return Acf::subField($name);
+    }
+}
+
+if (! function_exists('fluent_option')) {
+     /**
+     * Return a new builder instance for an option field call.
+     *
+     * @param  string  $name
+     * @return \Acf\Fluent\Builder
+     */
+    function fluent_option($name)
+    {
+        return Acf::option($name);
+    }
+}

--- a/tests/unit/HelpersTest.php
+++ b/tests/unit/HelpersTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use Acf\Test\TestCase;
+use Acf\Behaviors\FieldBehavior;
+use Acf\Behaviors\SubFieldBehavior;
+
+class HelpersTest extends TestCase
+{
+    public function testFluentFieldFunction()
+    {
+        $this->assertInstanceOf(
+            FieldBehavior::class,
+            fluent_field('foo')->getRunner()->getBehavior()
+        );
+    }
+
+    public function testFluentSubFieldFunction()
+    {
+        $this->assertInstanceOf(
+            SubFieldBehavior::class,
+            fluent_sub_field('foo')->getRunner()->getBehavior()
+        );
+    }
+
+    public function testFluentOptionFunction()
+    {
+        $builder = fluent_option('foo');
+
+        $this->assertInstanceOf(
+            FieldBehavior::class,
+            $builder->getRunner()->getBehavior()
+        );
+        $this->assertEquals('option', $builder->id);
+    }
+}


### PR DESCRIPTION
This PR adds the following (optional) helper functions to return new builders. This is an alternative to using the `Acf\Acf::field`, `Acf\Acf::subField`, and `Acf\Acf::option` methods, respectively:

```php
fluent_field('name');
fluent_sub_field('name');
fluent_option('name');
```