### PR TITLE
fix: fix phpdoc default()  param type

### DIFF
--- a/src/Fluent/Builder.php
+++ b/src/Fluent/Builder.php
@@ -141,7 +141,7 @@ class Builder
     /**
      * Set the default component.
      *
-     * @param  string  $default
+     * @param  mixed  $default
      * @return \Samrap\Acf\Fluent\Builder
      */
     public function default($default)


### PR DESCRIPTION
This fixes an incorrect param type for the default() function.

Current type is "string" but it should be mixed, identical to the $default var.